### PR TITLE
feat(changelog): Permet d'avoir un changelog personnalisé

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   "extends": "airbnb-base",
   "rules": {
     "no-use-before-define": "off",
+    "no-console": "off"
   },
   "plugins": [
     "import",

--- a/README.md
+++ b/README.md
@@ -15,12 +15,19 @@
 Il est possible d'exécuter un script :
 - après la confirmation de la création d'une release
 - après la création de la release
+- afficher un changelog personnalisé
 
-Ajout d'un fichier `.release.js` à la racine du projet.
+par défaut le changelog sera le suivant:
+`git log --merges --pretty='* %b (%h)' ${registry.currentVersion}..HEAD`
+
+---
+
+Ajouter un fichier `.release.js` à la racine du projet:
 
 ```
 module.exports = {
   preRelease: 'touch foo && git add foo && git commit -m "chore(deploy): update"',
-  postRelease: 'echo "release creation succeeded"'
+  postRelease: 'echo "release creation succeeded"',
+  changelogCmd: 'git log'
 };
 ```

--- a/cli.js
+++ b/cli.js
@@ -47,7 +47,14 @@ function cli() {
 
   if (cmd === 'init') return init({ mode, dryRun, ignoreStaged, ignoreIsMaster }, exit);
   if (cmd === 'add') return release({ mode, dryRun, ignoreStaged, ignoreIsMaster, staticConfig }, exit);
-  if (cmd === 'changelog') return changelog({ mode, staticConfig }, exit);
+  if (cmd === 'changelog') {
+    return changelog({ mode, staticConfig }, (err, changelogStr) => {
+      if (err) return exit(err);
+      console.log(changelogStr);
+      return exit();
+    });
+  }
+
   if (cmd !== 'help') console.info('Unknown command !!');
 
   displayHelp();

--- a/cli.js
+++ b/cli.js
@@ -47,7 +47,7 @@ function cli() {
 
   if (cmd === 'init') return init({ mode, dryRun, ignoreStaged, ignoreIsMaster }, exit);
   if (cmd === 'add') return release({ mode, dryRun, ignoreStaged, ignoreIsMaster, staticConfig }, exit);
-  if (cmd === 'changelog') return changelog({ mode }, exit);
+  if (cmd === 'changelog') return changelog({ mode, staticConfig }, exit);
   if (cmd !== 'help') console.info('Unknown command !!');
 
   displayHelp();

--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -4,9 +4,13 @@ const async = require('async');
 
 const services = require('./services');
 
-module.exports = ({ mode = 'patch', currentVersion = null }, callback) => {
+module.exports = ({
+  mode = 'patch',
+  currentVersion = null,
+  staticConfig = {},
+}, callback) => {
   async.waterfall([
-    next => getCurrentVersion({ mode, currentVersion }, next),
+    next => getCurrentVersion({ mode, currentVersion, staticConfig }, next),
     (registry, next) => getMergesSince(registry, next),
   ], callback);
 };
@@ -26,7 +30,10 @@ function getCurrentVersion(registry, callback) {
 }
 
 function getMergesSince(registry, callback) {
-  exec(`git log --merges --pretty='* %b (%h)' ${registry.currentVersion}..HEAD`, (err, changelog) => {
+  const changelogCmd = registry.staticConfig.changelogCmd ||
+    `git log --merges --pretty='* %b (%h)' ${registry.currentVersion}..HEAD`;
+
+  exec(changelogCmd, (err, changelog) => {
     if (err) return callback(err);
     return callback(null, `\nChangelog:\n${changelog}`);
   });


### PR DESCRIPTION
# Description
Rajouter dans le fichier `.release.js` la clé `changelogCmd` et y mettre sa commande personnalisé de changelog.
Le changelog par défaut est le suivant: 
```
git log --merges --pretty='* %b (%h)' ${registry.currentVersion}..HEAD
```