### PR TITLE
feat(changelog): Permet de passer une fonction en tant que changelogCmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Il est possible d'exécuter un script :
 - après la confirmation de la création d'une release
 - après la création de la release
-- afficher un changelog personnalisé
+- afficher un changelog personnalisé (string ou fonction, prenant en paramètre la version courante)
 
 par défaut le changelog sera le suivant:
 `git log --merges --pretty='* %b (%h)' ${registry.currentVersion}..HEAD`

--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -30,8 +30,17 @@ function getCurrentVersion(registry, callback) {
 }
 
 function getMergesSince(registry, callback) {
-  const changelogCmd = registry.staticConfig.changelogCmd ||
-    `git log --merges --pretty='* %b (%h)' ${registry.currentVersion}..HEAD`;
+  const changelogRegistry = registry.staticConfig.changelogCmd;
+  let changelogCmd;
+
+  if (!changelogRegistry) {
+    // default changelog cmd
+    changelogCmd = `git log --merges --pretty='* %b (%h)' ${registry.currentVersion}..HEAD`;
+  } else if (typeof changelogRegistry === 'string') {
+    changelogCmd = changelogRegistry;
+  } else if (typeof changelogRegistry === 'function') {
+    changelogCmd = changelogRegistry(registry.currentVersion);
+  }
 
   exec(changelogCmd, (err, changelog) => {
     if (err) return callback(err);


### PR DESCRIPTION
# Description

On peut désormais passer une fonction a `changelogCmd`qui prend en paramètre la version courante. 