### PR TITLE
fix(github-release-cli): fix github release cli path

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -114,7 +114,7 @@ module.exports.releaseLink = (version, callback) => {
 module.exports.createRelease = (dryRun, version, changelog = '', callback) => {
   console.log('... Create release using github-release');
 
-  const githubRelease = path.resolve(__dirname, '../node_modules/.bin/github-release');
+  const githubRelease = path.resolve(process.cwd(), 'node_modules/github-release-cli/bin/github-release');
 
   getRepoInfo((err, { owner, project }) => {
     const cmd = [


### PR DESCRIPTION
Selon si js-release était installé avec yarn ou npm, on avait un probleme pour retrouver le bin de github-release-cli. Maintenant, on devrait gérer les deux cas 

- [x] testé sur pattern-guide-cms + un autre projet npm
- [x] testé sur cms avec yarn