### PR TITLE
bug(changelog): release command crash if there is a double quote (")

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,11 @@
 module.exports = {
-  "extends": "airbnb-base",
-  "rules": {
-    "no-use-before-define": "off",
-    "no-console": "off"
+  extends: 'airbnb-base',
+  rules: {
+    'no-use-before-define': 'off',
+    'no-console': 'off',
   },
-  "plugins": [
-    "import",
-  ],
-  "globals": {
-    "console": true,
-  }
+  plugins: ['import'],
+  globals: {
+    console: true,
+  },
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+node_modules/**

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "semi": true
+}

--- a/cli.js
+++ b/cli.js
@@ -8,12 +8,14 @@ const { changelog, release, init } = require('./');
 const args = [].slice.call(process.argv, 2);
 const cmd = args[0];
 const dryRun = args.indexOf('-d') !== -1 || args.indexOf('--dry-run') !== -1;
-const ignoreStaged = args.indexOf('-i') !== -1 || args.indexOf('--ignore-not-staged') !== -1;
-const ignoreIsMaster = args.indexOf('-i') !== -1 || args.indexOf('--ignore-is-master') !== -1;
+const ignoreStaged =
+  args.indexOf('-i') !== -1 || args.indexOf('--ignore-not-staged') !== -1;
+const ignoreIsMaster =
+  args.indexOf('-i') !== -1 || args.indexOf('--ignore-is-master') !== -1;
 const help = args.indexOf('-h') !== -1 || args.indexOf('--help') !== -1;
 const mode = cmd === 'add' ? args[1] : null;
 
-const exit = (err) => {
+const exit = err => {
   if (err) console.error(err.message);
   process.exit(err ? 1 : 0);
 };
@@ -22,7 +24,9 @@ let version = '';
 let staticConfig = {};
 
 try {
-  version = JSON.parse(fs.readFileSync(path.resolve(__dirname, './package.json')).toString()).version;
+  version = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, './package.json')).toString()
+  ).version;
 } catch (err) {
   console.info(`Can't load package.json : ${err.message}`);
 }
@@ -43,10 +47,16 @@ function cli() {
 
   if (dryRun) console.log('Option: dry run mode');
   if (ignoreStaged) console.log('Option: changes not staged will be ignored');
-  if (ignoreIsMaster) console.log('Option: execution on branch master not required');
+  if (ignoreIsMaster)
+    console.log('Option: execution on branch master not required');
 
-  if (cmd === 'init') return init({ mode, dryRun, ignoreStaged, ignoreIsMaster }, exit);
-  if (cmd === 'add') return release({ mode, dryRun, ignoreStaged, ignoreIsMaster, staticConfig }, exit);
+  if (cmd === 'init')
+    return init({ mode, dryRun, ignoreStaged, ignoreIsMaster }, exit);
+  if (cmd === 'add')
+    return release(
+      { mode, dryRun, ignoreStaged, ignoreIsMaster, staticConfig },
+      exit
+    );
   if (cmd === 'changelog') {
     return changelog({ mode, staticConfig }, (err, changelogStr) => {
       if (err) return exit(err);
@@ -82,4 +92,3 @@ function displayHelp() {
 }
 
 cli();
-

--- a/lib/services.js
+++ b/lib/services.js
@@ -5,16 +5,19 @@ const mversion = require('mversion');
 const parseRepo = require('parse-repo');
 const path = require('path');
 
-const clean = str => str.replace(/\n/mg, '');
+const clean = str => str.replace(/\n/gm, '');
 
-module.exports.version = (callback) => {
+module.exports.version = callback => {
   exec('git describe --abbrev=0 --tags', (err, stdout, stderr) => {
-    if (/no names found/mig.test(stderr)) return askVersion(callback);
+    if (/no names found/gim.test(stderr)) return askVersion(callback);
     if (err) return callback(err);
 
     const currentVersion = clean(stdout);
 
-    if (!semver.valid(currentVersion)) return callback(new Error(`Current version is not a semver version : ${currentVersion}`));
+    if (!semver.valid(currentVersion))
+      return callback(
+        new Error(`Current version is not a semver version : ${currentVersion}`)
+      );
 
     return callback(null, currentVersion);
   });
@@ -28,7 +31,7 @@ function askVersion(callback) {
   });
 }
 
-module.exports.checkIfMaster = (callback) => {
+module.exports.checkIfMaster = callback => {
   console.log('... Checking if repo is master');
 
   exec('git rev-parse --abbrev-ref HEAD', (err, stdout) => {
@@ -37,7 +40,7 @@ module.exports.checkIfMaster = (callback) => {
   });
 };
 
-module.exports.noPendingModifications = (callback) => {
+module.exports.noPendingModifications = callback => {
   console.log('... Checking if repo has pending modifications');
 
   exec('git status --untracked-files=no --porcelain', (err, stdout) => {
@@ -46,24 +49,22 @@ module.exports.noPendingModifications = (callback) => {
   });
 };
 
-module.exports.pullMaster = (callback) => {
+module.exports.pullMaster = callback => {
   console.log('... Pulling changes from master');
 
   exec('git pull origin master', callback);
 };
 
-module.exports.fetchTags = (callback) => {
+module.exports.fetchTags = callback => {
   console.log('... Fetching remote tags');
 
   exec('git fetch --tags', callback);
 };
 
-module.exports.bumpVersion = ({
-  currentVersion,
-  nextVersion = null,
-  mode = null,
-  dryRun = false,
-}, callback) => {
+module.exports.bumpVersion = (
+  { currentVersion, nextVersion = null, mode = null, dryRun = false },
+  callback
+) => {
   console.log('... Create version using mVersion');
 
   let options = {};
@@ -103,18 +104,26 @@ module.exports.releaseLink = (version, callback) => {
   exec('git remote show origin', (err, stdout) => {
     if (err) return callback(err);
 
-    const fetchUrl = stdout.split('\n').find(line => /Fetch URL: (.*)\.git/mig.test(line));
+    const fetchUrl = stdout
+      .split('\n')
+      .find(line => /Fetch URL: (.*)\.git/gim.test(line));
     const githubRemoteUrl = fetchUrl.match(/Fetch URL: (.*)\.git/)[1];
 
     // (stdout.match(/Fetch URL: (.*)\.git/mig) || [])[1];
-    return callback(null, `New release github edit link: ${githubRemoteUrl}/releases/new?tag=${version}`);
+    return callback(
+      null,
+      `New release github edit link: ${githubRemoteUrl}/releases/new?tag=${version}`
+    );
   });
 };
 
 module.exports.createRelease = (dryRun, version, changelog = '', callback) => {
   console.log('... Create release using github-release');
 
-  const githubRelease = path.resolve(process.cwd(), 'node_modules/github-release-cli/bin/github-release');
+  const githubRelease = path.resolve(
+    process.cwd(),
+    'node_modules/github-release-cli/bin/github-release'
+  );
 
   getRepoInfo((err, { owner, project }) => {
     const cmd = [
@@ -140,6 +149,6 @@ module.exports.createRelease = (dryRun, version, changelog = '', callback) => {
 function getRepoInfo(callback) {
   exec('git config --get remote.origin.url', (err, stdout = '') => {
     if (err) return callback(err);
-    return callback(null, parseRepo(stdout.replace(/\s/mg, '')));
+    return callback(null, parseRepo(stdout.replace(/\s/gm, '')));
   });
 }

--- a/lib/services.js
+++ b/lib/services.js
@@ -132,7 +132,7 @@ module.exports.createRelease = (dryRun, version, changelog = '', callback) => {
       `--repo ${project}`,
       `--tag ${version}`,
       `--name "${version}"`,
-      `--body "${changelog}"`,
+      `--body "${changelog.replace(/"/gm, '\\"')}"`,
     ].join(' ');
 
     const link = `https://github.com/${owner}/${project}/releases/tag/${version}`;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "format": "prettier --write '{lib}/**/*.js' '*.js'"
   },
   "author": {
     "name": "JBustin"
@@ -27,7 +28,8 @@
   "devDependencies": {
     "eslint": "^3.19.0",
     "eslint-config-airbnb-base": "^11.2.0",
-    "eslint-plugin-import": "^2.3.0"
+    "eslint-plugin-import": "^2.3.0",
+    "prettier": "^1.15.2"
   },
   "dependencies": {
     "async": "2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1429,6 +1429,11 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
+prettier@^1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.2.tgz#d31abe22afa4351efa14c7f8b94b58bb7452205e"
+  integrity sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug==
+
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"


### PR DESCRIPTION
Ex:
```
Changelog:
* Revert "fix(graphql): Utilise api.search de la resource factory" 
* Revert "feat(client): bump to cms-client v0.12.0"
"
/bin/sh: -c: line 2: syntax error near unexpected token `('
/bin/sh: -c: line 2: `* Revert "fix(graphql): Utilise api.search de la resource factory" (c4e64a6)'
```